### PR TITLE
Setting rouge version to 1.6.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "http://rubygems.org"
 # Add dependencies required to use your gem here.
 gem 'rspec-core', '>= 3.0.3'
-gem 'rouge', '>= 1.6.1'
+gem 'rouge', '1.6.1'
 gem 'activesupport', '>= 4.1.4'
 
 # Add dependencies to develop your gem here.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,6 +82,6 @@ DEPENDENCIES
   bundler (~> 1.0)
   jeweler (~> 2.0.1)
   rdoc (~> 3.12)
-  rouge (>= 1.6.1)
+  rouge (= 1.6.1)
   rspec (~> 3.0.0)
   rspec-core (>= 3.0.3)

--- a/rspec_html_formatter.gemspec
+++ b/rspec_html_formatter.gemspec
@@ -56,7 +56,7 @@ Gem::Specification.new do |s|
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency(%q<rspec-core>, [">= 3.0.3"])
-      s.add_runtime_dependency(%q<rouge>, [">= 1.6.1"])
+      s.add_runtime_dependency(%q<rouge>, ["1.6.1"])
       s.add_runtime_dependency(%q<activesupport>, [">= 4.1.4"])
       s.add_development_dependency(%q<rspec>, ["~> 3.0.0"])
       s.add_development_dependency(%q<rdoc>, ["~> 3.12"])
@@ -64,7 +64,7 @@ Gem::Specification.new do |s|
       s.add_development_dependency(%q<jeweler>, ["~> 2.0.1"])
     else
       s.add_dependency(%q<rspec-core>, [">= 3.0.3"])
-      s.add_dependency(%q<rouge>, [">= 1.6.1"])
+      s.add_dependency(%q<rouge>, ["1.6.1"])
       s.add_dependency(%q<activesupport>, [">= 4.1.4"])
       s.add_dependency(%q<rspec>, ["~> 3.0.0"])
       s.add_dependency(%q<rdoc>, ["~> 3.12"])
@@ -73,7 +73,7 @@ Gem::Specification.new do |s|
     end
   else
     s.add_dependency(%q<rspec-core>, [">= 3.0.3"])
-    s.add_dependency(%q<rouge>, [">= 1.6.1"])
+    s.add_dependency(%q<rouge>, ["1.6.1"])
     s.add_dependency(%q<activesupport>, [">= 4.1.4"])
     s.add_dependency(%q<rspec>, ["~> 3.0.0"])
     s.add_dependency(%q<rdoc>, ["~> 3.12"])


### PR DESCRIPTION
With latest 2.0.7 version the report formatting breaks. http://joxi.ru/J2banRhXoLddm6
To fix this I set rouge version to 1.6.1 to permanent. Now it's works correct